### PR TITLE
feat: implement paddi init command and HonKit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,113 +7,397 @@
 ![Code size](https://img.shields.io/github/languages/code-size/susumutomita/Paddi)
 ![Repo size](https://img.shields.io/github/repo-size/susumutomita/Paddi)
 
-**Paddi** is a multi-agent system that automates cloud security audits using Google Cloud AI and CLI.
-It uses three lightweight agents to collect configurations and analyze risks.
-These agents work together to generate human-readable reports.
+**Paddi** is a multi-agent system that automates cloud security audits using Google Cloud AI and a unified CLI interface. It orchestrates three specialized agents that work together to collect configurations, analyze security risks with AI, and generate comprehensive audit reports.
 
-Built for the [Google Cloud AI Hackathon: Multi-Agent Edition](https://googlecloudmultiagents.devpost.com/).
-This project demonstrates how AI agents can assist security workflows by reducing manual effort.
+Built for the [Google Cloud AI Hackathon: Multi-Agent Edition](https://googlecloudmultiagents.devpost.com/). This project demonstrates how AI agents can transform security workflows by automating manual audit processes while maintaining enterprise-grade quality.
 
 ---
 
-## 🚀 Features
+## 🚀 Quick Start
 
-- ✅ **Google Cloud native** (uses IAM, SCC, and Gemini via Vertex AI)
-- 🧠 **Multi-agent architecture**: modular and composable
-- 📝 **Report generation** in Markdown and HTML
-- 💡 CLI-first, no frontend dependencies
-- 🐍 Python for rapid iteration (will migrate to Rust CLI later)
-- 🔐 Ideal for internal auditors and DevSecOps teams
+Get started with Paddi in less than a minute:
+
+```bash
+# Install Paddi (future Homebrew support)
+# brew install paddi
+
+# Try Paddi with sample data - zero configuration needed!
+paddi init
+
+# Output:
+# ✅ Paddi init 完了:
+#   • Markdown: output/audit.md
+#   • HTML: output/audit.html（ブラウザで開けます）
+#   • サイトプレビュー: npx honkit serve docs/
+```
+
+That's it! Paddi automatically runs the full audit pipeline with sample GCP data, demonstrating its capabilities without requiring any GCP credentials or setup.
 
 ---
 
-## 🧩 Architecture
+## 🏗️ Architecture
 
-```text
-+----------------+       +----------------+       +-----------------+
-| Agent A:       | --->  | Agent B:       | --->  | Agent C:        |
-|  Collector     |       |  Explainer     |       |  Reporter       |
-|  (GCP config)  |       |  (Gemini LLM)  |       |  (Markdown/HTML)|
-+----------------+       +----------------+       +-----------------+
+Paddi implements a **three-agent pipeline** architecture, where each agent has a single, well-defined responsibility:
 
-Each agent is an independent Python script and can be run locally or integrated into automation pipelines.
+```mermaid
+graph LR
+    A[Collector Agent] -->|collected.json| B[Explainer Agent]
+    B -->|explained.json| C[Reporter Agent]
+    C --> D[Audit Reports]
+    
+    style A fill:#4285f4,stroke:#1a73e8,stroke-width:2px,color:#fff
+    style B fill:#ea4335,stroke:#d33b27,stroke-width:2px,color:#fff
+    style C fill:#34a853,stroke:#1e8e3e,stroke-width:2px,color:#fff
+    style D fill:#fbbc04,stroke:#f9ab00,stroke-width:2px,color:#000
+```
 
-⸻
+### Agent Details
 
-📁 Repository Layout
+#### 1. **Collector Agent** (`python_agents/collector/`)
+- **Purpose**: Gather GCP configuration data
+- **Input**: GCP project ID or mock data flag
+- **Output**: `data/collected.json` containing IAM policies and Security Command Center findings
+- **Key Features**:
+  - Real GCP API integration via `google-cloud-iam` and `google-cloud-securitycenter`
+  - Mock data support for testing and demos
+  - Extensible to support multiple cloud providers
 
-paddi/
-├── python_agents/
-│   ├── collector/         # Agent A: GCP config retriever
-│   ├── explainer/         # Agent B: Gemini-based LLM analyzer
-│   ├── reporter/          # Agent C: Markdown/HTML renderer
-│   └── requirements.txt   # Shared dependencies
-├── cli/                   # Future Rust-based CLI
-├── templates/             # Jinja2 templates for output
-├── examples/              # Example IAM and SCC data
-└── README.md              # This file
+#### 2. **Explainer Agent** (`python_agents/explainer/`)
+- **Purpose**: Analyze security risks using AI
+- **Input**: `data/collected.json` from Collector
+- **Output**: `data/explained.json` with AI-generated security insights
+- **Key Features**:
+  - Powered by Google's Gemini AI (via Vertex AI)
+  - Categorizes findings by severity (CRITICAL, HIGH, MEDIUM, LOW)
+  - Provides actionable recommendations in natural language
+  - Mock mode for offline development
 
+#### 3. **Reporter Agent** (`python_agents/reporter/`)
+- **Purpose**: Generate human-readable audit reports
+- **Input**: `data/explained.json` from Explainer
+- **Output**: Multiple report formats:
+  - `output/audit.md` - Markdown for documentation tools
+  - `output/audit.html` - Interactive HTML report
+  - `docs/` - HonKit site structure for web hosting
+- **Key Features**:
+  - Jinja2 templating for customizable reports
+  - Multiple output formats
+  - Severity-based organization
+  - Japanese and English support
 
-⸻
+### Orchestration Layer
 
-⚙️ How to Run
+The **Rust CLI** (`cli/`) provides a unified interface to orchestrate the Python agents:
 
-1. Set up
+```rust
+// Simplified orchestration flow
+orchestrator.run_collector()?;
+orchestrator.run_explainer()?;
+orchestrator.run_reporter(formats)?;
+```
 
-cd paddi/python_agents
-python3 -m venv venv
+---
+
+## 📚 CLI Usage Guide
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/susumutomita/Paddi.git
+cd Paddi
+
+# Build the Rust CLI
+cd cli
+cargo build --release
+
+# Add to PATH (or use cargo install)
+export PATH=$PATH:$(pwd)/target/release
+```
+
+### Core Commands
+
+#### `paddi init` - Zero-Setup Trial
+```bash
+# Run a complete audit with sample data
+paddi init
+
+# Skip the automatic pipeline run
+paddi init --skip-run
+
+# Specify output directory
+paddi init --output custom-output/
+```
+
+#### `paddi audit` - Full Pipeline
+```bash
+# Run complete audit pipeline
+paddi audit
+
+# Use mock data instead of real GCP
+paddi audit --use-mock
+
+# Specify GCP project
+paddi audit --project-id my-gcp-project
+
+# Verbose output
+paddi audit -v
+```
+
+#### `paddi collect` - Data Collection Only
+```bash
+# Collect from real GCP project
+paddi collect --project-id my-gcp-project
+
+# Collect mock data for testing
+paddi collect --use-mock
+```
+
+#### `paddi analyze` - AI Analysis Only
+```bash
+# Analyze collected data with AI
+paddi analyze
+
+# Use mock AI responses
+paddi analyze --use-mock
+```
+
+#### `paddi report` - Generate Reports
+```bash
+# Generate default reports (Markdown + HTML)
+paddi report
+
+# Generate specific formats
+paddi report --format markdown,html,honkit
+
+# Custom input/output directories
+paddi report --input-dir data/ --output-dir reports/
+```
+
+#### `paddi config` - Configuration Management
+```bash
+# Show current configuration
+paddi config show
+
+# Validate configuration
+paddi config validate
+
+# Initialize new configuration
+paddi config init
+```
+
+### Configuration
+
+Paddi uses TOML configuration files. Create `paddi.toml`:
+
+```toml
+[gcp]
+project_id = "my-gcp-project"
+use_mock = false
+
+[paths]
+data_dir = "data"
+output_dir = "output"
+
+[python]
+command = "python3"
+agents_path = "python_agents"
+
+[execution]
+timeout_seconds = 300
+```
+
+### Environment Variables
+
+- `PADDI_CONFIG` - Path to configuration file
+- `GOOGLE_APPLICATION_CREDENTIALS` - GCP service account key
+- `RUST_LOG` - Logging level (info, debug, trace)
+
+---
+
+## 🎯 Use Cases
+
+### 1. **Development & Testing**
+```bash
+# Quick start with sample data
+paddi init
+
+# Test individual agents
+paddi collect --use-mock
+paddi analyze --use-mock
+paddi report
+```
+
+### 2. **Real GCP Audits**
+```bash
+# Authenticate with GCP
+gcloud auth application-default login
+
+# Run full audit
+paddi audit --project-id production-project
+```
+
+### 3. **CI/CD Integration**
+```yaml
+# GitHub Actions example
+- name: Run Security Audit
+  run: |
+    paddi audit --project-id ${{ secrets.GCP_PROJECT }}
+    
+- name: Upload Reports
+  uses: actions/upload-artifact@v3
+  with:
+    name: audit-reports
+    path: output/
+```
+
+### 4. **Scheduled Audits**
+```bash
+# Cron job for weekly audits
+0 0 * * 0 paddi audit --project-id prod && \
+  gsutil cp output/audit.html gs://audit-reports/$(date +%Y%m%d).html
+```
+
+---
+
+## 📊 Sample Output
+
+### Markdown Report (`output/audit.md`)
+```markdown
+# Security Audit Report - example-project-123
+
+**Audit Date:** 2024-01-21
+**Total Findings:** 4
+
+## Executive Summary
+
+This security audit identified 4 findings across your GCP infrastructure.
+
+### Severity Breakdown
+- **CRITICAL**: 1 findings
+- **HIGH**: 1 findings
+- **MEDIUM**: 1 findings
+- **LOW**: 1 findings
+
+## Detailed Findings
+
+### 1. Public Bucket Access
+**Severity:** CRITICAL
+**Explanation:** The bucket 'sensitive-data-bucket' has public access enabled...
+**Recommendation:** Remove allUsers and allAuthenticatedUsers from bucket IAM policy
+```
+
+### HonKit Documentation (`docs/`)
+- Interactive web documentation
+- Severity-based navigation
+- Japanese localization
+- Searchable content
+- Export to PDF capability
+
+---
+
+## 🛠️ Development
+
+### Prerequisites
+- Python 3.10+
+- Rust 1.70+
+- Google Cloud SDK (for real GCP audits)
+
+### Setup Development Environment
+```bash
+# Python agents
+cd python_agents
+python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 
-Ensure gcloud auth application-default login is configured if using Gemini (Vertex AI).
+# Rust CLI
+cd ../cli
+cargo build
+cargo test
 
-2. Run Agents
+# Run quality checks
+cd ../python_agents
+make before-commit
+```
 
-# Step 1: Collect GCP configs (mocked for now)
-python collector/agent_collector.py
+### Testing
+```bash
+# Python tests
+pytest --cov=. --cov-report=term-missing
 
-# Step 2: Explain security risks using Gemini
-python explainer/agent_explainer.py
+# Rust tests
+cargo test
 
-# Step 3: Generate Markdown and HTML reports
-python reporter/agent_reporter.py
+# Integration tests
+./scripts/integration_test.sh
+```
 
+---
 
-⸻
+## 🌐 Tech Stack
 
-📄 Sample Output
-- output/audit.md: Markdown-formatted audit report
-- output/audit.html: Web-friendly version
-- YAML frontmatter includes metadata
+- **Python 3.10+**: Agent implementation
+- **Rust**: CLI and orchestration
+- **Google Vertex AI**: Gemini Pro for AI analysis
+- **Google Cloud APIs**: IAM, Security Command Center
+- **Jinja2**: Report templating
+- **HonKit**: Documentation generation
+- **Tokio**: Async runtime for Rust
 
-⸻
+---
 
-🌐 Tech Stack
-- Python 3.10+
-- Google Vertex AI (Gemini Pro via google-cloud-aiplatform)
-- Jinja2 templating
-- CLI integration planned with Rust (via cargo build --release)
-- Markdown + HTML output for compatibility with tools like Obsidian
+## 🚀 Roadmap
 
-⸻
+- [ ] Homebrew formula for easy installation
+- [ ] Support for AWS and Azure
+- [ ] Custom rule definitions
+- [ ] Slack/Teams notifications
+- [ ] Compliance frameworks (SOC2, ISO27001)
+- [ ] Web UI dashboard
+- [ ] Agent marketplace
 
-🧠 Vision
+---
 
-While this project is a prototype, it is designed with extensibility and enterprise adoption in mind:
-- Replace manual cloud audits with reproducible, code-based checks
-- Allow pluggable rules, agent chaining, and version-controlled evidence
-- Future-proof CLI for multi-platform distribution (macOS/Linux/Windows)
+## 👥 Contributors
 
-⸻
+- **Strategy & Architecture**: [Susumu Tomita](https://susumutomita.netlify.app/) - Full Stack Developer
+- **Implementation**: Claude Code + AI collaboration
 
-👥 Authors
-- Strategy & Architecture: [Susumu Tomita](https://susumutomita.netlify.app/) - Full Stack Developer
-- Implementation: Claude Code + AI collaboration
+## 🤝 Contributing
 
-## Contribution
+We welcome contributions! Please see our [Contributing Guide](docs/contributing/development.md) for details.
 
-We welcome contributions. Please submit proposals via pull requests or issues.
+```bash
+# Fork and clone
+git clone https://github.com/YOUR-USERNAME/Paddi.git
 
-## License
+# Create feature branch
+git checkout -b feature/amazing-feature
 
-MissionChain is licensed under the [MIT License](LICENSE).
+# Make changes and test
+make test
+
+# Submit PR
+git push origin feature/amazing-feature
+```
+
+---
+
+## 📄 License
+
+Paddi is licensed under the [MIT License](LICENSE).
+
+---
+
+## 🙏 Acknowledgments
+
+- Google Cloud AI Hackathon organizers
+- The open-source community
+- Early adopters and testers
+
+---
+
+<p align="center">
+  Made with ❤️ for the security community
+</p>

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,0 +1,217 @@
+use anyhow::{Context, Result};
+use clap::Args;
+use std::fs;
+use std::path::Path;
+use tracing::{info, warn};
+
+use crate::config::Config;
+use crate::orchestrator::AgentOrchestrator;
+
+#[derive(Args)]
+pub struct InitArgs {
+    #[arg(
+        short,
+        long,
+        help = "Output directory for generated files",
+        default_value = "output"
+    )]
+    output: String,
+
+    #[arg(
+        long,
+        help = "Skip running the full pipeline after initialization"
+    )]
+    skip_run: bool,
+}
+
+pub async fn run(args: InitArgs, mut config: Config) -> Result<()> {
+    info!("🚀 Initializing Paddi with sample data...");
+
+    // Create necessary directories
+    create_directories(&args.output)?;
+
+    // Copy sample data to the data directory
+    setup_sample_data()?;
+
+    // Update config to use the sample data
+    config.collector.use_mock = true;
+    config.explainer.mock_mode = true;
+    
+    if !args.skip_run {
+        info!("🔄 Running full audit pipeline with sample data...");
+        
+        // Create orchestrator and run the full pipeline
+        let orchestrator = AgentOrchestrator::new(config);
+        
+        // Run collector
+        info!("📊 Collecting sample GCP configuration data...");
+        orchestrator.run_collector(Some(true), None).await
+            .context("Failed to run collector")?;
+        
+        // Run explainer
+        info!("🧠 Analyzing security risks with AI...");
+        orchestrator.run_explainer(Some(true), None).await
+            .context("Failed to run explainer")?;
+        
+        // Run reporter with both markdown and html formats
+        info!("📝 Generating audit reports...");
+        let formats = vec!["markdown".to_string(), "html".to_string(), "honkit".to_string()];
+        orchestrator.run_reporter(None, None, Some(formats)).await
+            .context("Failed to run reporter")?;
+        
+        // Print success message with file locations
+        println!("\n✅ Paddi init 完了:");
+        println!("  • Markdown: {}/audit.md", args.output);
+        println!("  • HTML: {}/audit.html（ブラウザで開けます）", args.output);
+        
+        // Check if honkit is available and provide guidance
+        if which::which("honkit").is_ok() || which::which("npx").is_ok() {
+            println!("  • サイトプレビュー: npx honkit serve docs/");
+        } else {
+            println!("  • サイトプレビュー: npm install -g honkit && honkit serve docs/");
+        }
+    } else {
+        info!("✅ Initialization complete. Sample data is ready in data/collected.json");
+        info!("Run 'paddi audit' to execute the full pipeline.");
+    }
+
+    Ok(())
+}
+
+fn create_directories(output_dir: &str) -> Result<()> {
+    let dirs = vec!["data", output_dir, "docs"];
+    
+    for dir in dirs {
+        fs::create_dir_all(dir)
+            .with_context(|| format!("Failed to create directory: {}", dir))?;
+        info!("📁 Created directory: {}", dir);
+    }
+    
+    Ok(())
+}
+
+fn setup_sample_data() -> Result<()> {
+    let sample_file = "examples/gcp_sample.json";
+    let target_file = "data/collected.json";
+    
+    // Check if sample file exists
+    if !Path::new(sample_file).exists() {
+        // If not, create it with embedded sample data
+        create_sample_file(sample_file)?;
+    }
+    
+    // Copy sample data to data directory
+    fs::copy(sample_file, target_file)
+        .with_context(|| format!("Failed to copy {} to {}", sample_file, target_file))?;
+    
+    info!("📋 Sample GCP configuration data copied to {}", target_file);
+    
+    Ok(())
+}
+
+fn create_sample_file(path: &str) -> Result<()> {
+    // Create examples directory if it doesn't exist
+    if let Some(parent) = Path::new(path).parent() {
+        fs::create_dir_all(parent)?;
+    }
+    
+    // Embedded sample data
+    let sample_data = r#"{
+  "iam_policies": [
+    {
+      "resource": "projects/example-project-123",
+      "bindings": [
+        {
+          "role": "roles/owner",
+          "members": [
+            "user:admin@example.com",
+            "serviceAccount:test-sa@example-project-123.iam.gserviceaccount.com"
+          ]
+        },
+        {
+          "role": "roles/editor",
+          "members": [
+            "user:developer@example.com",
+            "group:dev-team@example.com"
+          ]
+        },
+        {
+          "role": "roles/viewer",
+          "members": [
+            "allUsers"
+          ]
+        },
+        {
+          "role": "roles/storage.admin",
+          "members": [
+            "user:storage-admin@example.com",
+            "serviceAccount:storage-sa@example-project-123.iam.gserviceaccount.com"
+          ]
+        }
+      ]
+    },
+    {
+      "resource": "buckets/sensitive-data-bucket",
+      "bindings": [
+        {
+          "role": "roles/storage.objectViewer",
+          "members": [
+            "allAuthenticatedUsers"
+          ]
+        }
+      ]
+    }
+  ],
+  "scc_findings": [
+    {
+      "name": "organizations/123456789/sources/1234567890/findings/finding-1",
+      "category": "PUBLIC_BUCKET_ACL",
+      "resourceName": "//storage.googleapis.com/sensitive-data-bucket",
+      "state": "ACTIVE",
+      "severity": "CRITICAL",
+      "finding": {
+        "description": "Bucket has public access enabled",
+        "recommendation": "Remove allUsers and allAuthenticatedUsers from bucket IAM policy"
+      }
+    },
+    {
+      "name": "organizations/123456789/sources/1234567890/findings/finding-2",
+      "category": "OVER_PRIVILEGED_SERVICE_ACCOUNT",
+      "resourceName": "//iam.googleapis.com/projects/example-project-123/serviceAccounts/test-sa@example-project-123.iam.gserviceaccount.com",
+      "state": "ACTIVE",
+      "severity": "HIGH",
+      "finding": {
+        "description": "Service account has owner role",
+        "recommendation": "Follow least privilege principle and grant only necessary permissions"
+      }
+    },
+    {
+      "name": "organizations/123456789/sources/1234567890/findings/finding-3",
+      "category": "WEAK_SSL_POLICY",
+      "resourceName": "//compute.googleapis.com/projects/example-project-123/global/sslPolicies/weak-ssl-policy",
+      "state": "ACTIVE",
+      "severity": "MEDIUM",
+      "finding": {
+        "description": "SSL policy allows TLS 1.0 and TLS 1.1",
+        "recommendation": "Update SSL policy to use minimum TLS 1.2"
+      }
+    },
+    {
+      "name": "organizations/123456789/sources/1234567890/findings/finding-4",
+      "category": "UNUSED_IAM_ROLE",
+      "resourceName": "//iam.googleapis.com/projects/example-project-123/roles/customRole123",
+      "state": "ACTIVE",
+      "severity": "LOW",
+      "finding": {
+        "description": "Custom role has not been used in 90 days",
+        "recommendation": "Review and remove unused custom roles"
+      }
+    }
+  ]
+}"#;
+    
+    fs::write(path, sample_data)
+        .with_context(|| format!("Failed to create sample file: {}", path))?;
+    
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub mod analyze;
 pub mod audit;
 pub mod collect;
 pub mod config;
+pub mod init;
 pub mod report;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ mod commands;
 mod config;
 mod orchestrator;
 
-use commands::{analyze, audit, collect, config as config_cmd, report};
+use commands::{analyze, audit, collect, config as config_cmd, init, report};
 use config::Config;
 
 #[derive(Parser)]
@@ -44,6 +44,9 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    #[command(about = "Initialize Paddi with sample data for quick trial")]
+    Init(init::InitArgs),
+
     #[command(about = "Run full audit pipeline")]
     Audit(audit::AuditArgs),
 
@@ -98,6 +101,7 @@ async fn main() -> Result<()> {
 
     // Execute command
     match cli.command {
+        Commands::Init(args) => init::run(args, config).await,
         Commands::Audit(args) => audit::run(args, config).await,
         Commands::Collect(args) => collect::run(args, config).await,
         Commands::Analyze(args) => analyze::run(args, config).await,

--- a/cli/src/orchestrator/mod.rs
+++ b/cli/src/orchestrator/mod.rs
@@ -73,7 +73,7 @@ impl AgentOrchestrator {
         self.run_python_agent("explainer/agent_explainer.py", &args).await
     }
 
-    pub async fn run_reporter(&self, input_dir: Option<PathBuf>, output_dir: Option<PathBuf>) -> Result<AgentResult> {
+    pub async fn run_reporter(&self, input_dir: Option<PathBuf>, output_dir: Option<PathBuf>, formats: Option<Vec<String>>) -> Result<AgentResult> {
         self.set_progress_message("Running reporter agent...");
         
         let mut args = vec![];
@@ -84,6 +84,10 @@ impl AgentOrchestrator {
         
         if let Some(output_dir) = output_dir.or(Some(self.config.paths.output_dir.clone())) {
             args.push(format!("--output_dir={}", output_dir.display()));
+        }
+        
+        if let Some(formats) = formats {
+            args.push(format!("--formats=[{}]", formats.join(",")));
         }
         
         self.run_python_agent("reporter/agent_reporter.py", &args).await
@@ -116,7 +120,7 @@ impl AgentOrchestrator {
         info!("Explainer agent completed successfully");
         
         // Run reporter
-        let reporter_result = self.run_reporter(None, None).await?;
+        let reporter_result = self.run_reporter(None, None, None).await?;
         if !reporter_result.success {
             error!("Reporter agent failed: {}", reporter_result.error);
             anyhow::bail!("Reporter agent failed");

--- a/examples/gcp_sample.json
+++ b/examples/gcp_sample.json
@@ -1,0 +1,93 @@
+{
+  "iam_policies": [
+    {
+      "resource": "projects/example-project-123",
+      "bindings": [
+        {
+          "role": "roles/owner",
+          "members": [
+            "user:admin@example.com",
+            "serviceAccount:test-sa@example-project-123.iam.gserviceaccount.com"
+          ]
+        },
+        {
+          "role": "roles/editor",
+          "members": [
+            "user:developer@example.com",
+            "group:dev-team@example.com"
+          ]
+        },
+        {
+          "role": "roles/viewer",
+          "members": [
+            "allUsers"
+          ]
+        },
+        {
+          "role": "roles/storage.admin",
+          "members": [
+            "user:storage-admin@example.com",
+            "serviceAccount:storage-sa@example-project-123.iam.gserviceaccount.com"
+          ]
+        }
+      ]
+    },
+    {
+      "resource": "buckets/sensitive-data-bucket",
+      "bindings": [
+        {
+          "role": "roles/storage.objectViewer",
+          "members": [
+            "allAuthenticatedUsers"
+          ]
+        }
+      ]
+    }
+  ],
+  "scc_findings": [
+    {
+      "name": "organizations/123456789/sources/1234567890/findings/finding-1",
+      "category": "PUBLIC_BUCKET_ACL",
+      "resourceName": "//storage.googleapis.com/sensitive-data-bucket",
+      "state": "ACTIVE",
+      "severity": "CRITICAL",
+      "finding": {
+        "description": "Bucket has public access enabled",
+        "recommendation": "Remove allUsers and allAuthenticatedUsers from bucket IAM policy"
+      }
+    },
+    {
+      "name": "organizations/123456789/sources/1234567890/findings/finding-2",
+      "category": "OVER_PRIVILEGED_SERVICE_ACCOUNT",
+      "resourceName": "//iam.googleapis.com/projects/example-project-123/serviceAccounts/test-sa@example-project-123.iam.gserviceaccount.com",
+      "state": "ACTIVE",
+      "severity": "HIGH",
+      "finding": {
+        "description": "Service account has owner role",
+        "recommendation": "Follow least privilege principle and grant only necessary permissions"
+      }
+    },
+    {
+      "name": "organizations/123456789/sources/1234567890/findings/finding-3",
+      "category": "WEAK_SSL_POLICY",
+      "resourceName": "//compute.googleapis.com/projects/example-project-123/global/sslPolicies/weak-ssl-policy",
+      "state": "ACTIVE",
+      "severity": "MEDIUM",
+      "finding": {
+        "description": "SSL policy allows TLS 1.0 and TLS 1.1",
+        "recommendation": "Update SSL policy to use minimum TLS 1.2"
+      }
+    },
+    {
+      "name": "organizations/123456789/sources/1234567890/findings/finding-4",
+      "category": "UNUSED_IAM_ROLE",
+      "resourceName": "//iam.googleapis.com/projects/example-project-123/roles/customRole123",
+      "state": "ACTIVE",
+      "severity": "LOW",
+      "finding": {
+        "description": "Custom role has not been used in 90 days",
+        "recommendation": "Review and remove unused custom roles"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR implements the `paddi init` command for zero-setup trial experience, adds HonKit documentation output support, and enhances the README with comprehensive documentation.

## Changes
- ✨ Added `paddi init` command that provides instant trial with sample data
- 📚 Added HonKit generator for web documentation output
- 📝 Enhanced README with architecture diagrams and CLI usage guide
- 🔧 Updated reporter to support multiple output formats

Closes #17

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a CLI command to quickly initialize the application with sample data and optionally run a full audit pipeline.
  - Added support for generating HonKit-compatible documentation for security audit reports, including executive summaries, severity-level details, methodology, and glossary.
  - Enhanced report generation to allow users to specify output formats (Markdown, HTML, HonKit) via CLI options.
  - Included a sample GCP IAM and security findings JSON file for easier onboarding and testing.

- **Documentation**
  - Completely overhauled the README with detailed guides, architecture diagrams, CLI usage instructions, development setup, use cases, sample outputs, roadmap, and contributor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->