### PR TITLE
fix: correct before-commit target naming and add PHONY declaration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ format:
 	black .
 	isort .
 
-.PHONY: before_commit
-before_commit: test format lint
+.PHONY: before-commit
+before-commit: test format lint
 
 # -------------------------------
 # Presentation


### PR DESCRIPTION
Fixes #20

## Changes
- Change `before_commit` to `before-commit` for consistency
- Add `.PHONY` declaration for before-commit target
- Ensures `make before-commit` works as specified in CLAUDE.md

Generated with [Claude Code](https://claude.ai/code)