### PR TITLE
fix: set default template directory path for reporter agent

### DIFF
--- a/app/reporter/agent_reporter.py
+++ b/app/reporter/agent_reporter.py
@@ -583,7 +583,7 @@ class ReportService:
 def main(
     input_dir: str = "data",
     output_dir: str = "output",
-    template_dir: Optional[str] = None,
+    template_dir: Optional[str] = "app/templates",
     formats: Optional[List[str]] = None,
 ):
     """Generate security audit reports from explained findings.

--- a/app/tests/test_reporter.py
+++ b/app/tests/test_reporter.py
@@ -358,7 +358,7 @@ class TestMainFunction:
         mock_service_class.assert_called_once_with(
             input_dir=Path("data"),
             output_dir=Path("output"),
-            template_dir=None,
+            template_dir=Path("app/templates"),
         )
         mock_instance.generate_reports.assert_called_once()
 


### PR DESCRIPTION
Fixes #23

This PR updates the default template directory path for the reporter agent to automatically use the existing template at `app/templates/report.md.j2`.

## Changes
- Updated `template_dir` parameter default from `None` to `"app/templates"`
- Updated corresponding unit test

## Impact
- Users no longer need to manually specify the template directory path
- The Jinja2 template will be used automatically for report generation

Generated with [Claude Code](https://claude.ai/code)