### PR TITLE
fix: wrap metadata fields in collector output

### DIFF
--- a/app/collector/agent_collector.py
+++ b/app/collector/agent_collector.py
@@ -167,9 +167,11 @@ class GCPConfigurationCollector:
         logger.info("Starting GCP configuration collection for project: %s", self.project_id)
 
         collected_data = {
-            "project_id": self.project_id,
-            "organization_id": self.organization_id,
-            "timestamp": self._get_timestamp(),
+            "metadata": {
+                "project_id": self.project_id,
+                "organization_id": self.organization_id,
+                "timestamp": self._get_timestamp(),
+            },
             "iam_policies": self.iam_collector.collect(),
             "scc_findings": self.scc_collector.collect(),
         }

--- a/app/tests/test_collector.py
+++ b/app/tests/test_collector.py
@@ -106,9 +106,10 @@ class TestGCPConfigurationCollector:
 
         data = collector.collect_all()
 
-        assert data["project_id"] == "test-project"
-        assert data["organization_id"] == "test-org"
-        assert "timestamp" in data
+        assert "metadata" in data
+        assert data["metadata"]["project_id"] == "test-project"
+        assert data["metadata"]["organization_id"] == "test-org"
+        assert "timestamp" in data["metadata"]
         assert "iam_policies" in data
         assert "scc_findings" in data
         assert isinstance(data["iam_policies"], dict)
@@ -133,8 +134,9 @@ class TestGCPConfigurationCollector:
         with open(output_path, "r") as f:
             saved_data = json.load(f)
 
-        assert saved_data["project_id"] == "test-project"
-        assert saved_data["organization_id"] == "test-org"
+        assert "metadata" in saved_data
+        assert saved_data["metadata"]["project_id"] == "test-project"
+        assert saved_data["metadata"]["organization_id"] == "test-org"
 
     def test_save_to_file_custom_filename(self, temp_output_dir):
         """Test saving with custom filename"""


### PR DESCRIPTION
The collector now properly saves project_id, organization_id, and timestamp
under a "metadata" field as expected by the reporter agent. This fixes the
data structure mismatch between agents.

Fixes #22

Generated with [Claude Code](https://claude.ai/code)