### PR TITLE
[Step 1] モックデータ利用の停止 - use_mock=Falseへの変更

### DIFF
--- a/app/collector/agent_collector.py
+++ b/app/collector/agent_collector.py
@@ -200,7 +200,7 @@ class GCPConfigurationCollector:
 def main(
     project_id: Optional[str] = None,
     organization_id: Optional[str] = None,
-    use_mock: bool = True,
+    use_mock: bool = False,
     output_dir: str = "data",
     provider: str = "gcp",
     providers: Optional[str] = None,

--- a/app/explainer/agent_explainer.py
+++ b/app/explainer/agent_explainer.py
@@ -610,7 +610,7 @@ class SecurityRiskExplainer:
 def main(
     project_id: str = "example-project",
     location: str = "us-central1",
-    use_mock: bool = True,
+    use_mock: bool = False,
     input_file: str = "data/collected.json",
     output_dir: str = "data",
 ):

--- a/app/main.py
+++ b/app/main.py
@@ -73,7 +73,7 @@ class PaddiCLI:
         self,
         project_id: str = "example-project-123",
         organization_id: Optional[str] = None,
-        use_mock: bool = True,
+        use_mock: bool = False,
         location: str = "us-central1",
         output_dir: str = "output",
         verbose: bool = False,


### PR DESCRIPTION
Fixes #63

Changed the default value of `use_mock` parameter from `True` to `False` to enable real data collection by default.

This ensures the application connects to real cloud environments by default, while tests continue to use mock data.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The default behavior now uses real cloud data collection and analysis instead of mock data across the application, providing users with live results unless mock mode is explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->