### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/web/static/js/dashboard.js
+++ b/web/static/js/dashboard.js
@@ -334,10 +334,15 @@ function addChatMessage(message, sender) {
     messageDiv.className = `chat-message ${sender}`;
     
     const icon = sender === 'user' ? 'person' : 'smart_toy';
-    messageDiv.innerHTML = `
-        <span class="material-icons">${icon}</span>
-        <p>${message}</p>
-    `;
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'material-icons';
+    iconSpan.textContent = icon;
+    
+    const messageParagraph = document.createElement('p');
+    messageParagraph.textContent = message;
+    
+    messageDiv.appendChild(iconSpan);
+    messageDiv.appendChild(messageParagraph);
     
     chatContainer.appendChild(messageDiv);
     chatContainer.scrollTop = chatContainer.scrollHeight;


### PR DESCRIPTION
Potential fix for [https://github.com/susumutomita/Paddi/security/code-scanning/9](https://github.com/susumutomita/Paddi/security/code-scanning/9)

To fix the issue, we need to ensure that user input is properly sanitized or escaped before being inserted into the DOM. Instead of using `innerHTML`, which interprets the string as HTML, we should use `textContent` to safely insert the text as plain text. This prevents any HTML or JavaScript code from being executed.

The changes will involve:
1. Replacing `messageDiv.innerHTML` with a safer alternative that does not interpret the input as HTML.
2. Creating separate DOM elements for the icon and message text to maintain the intended structure and styling.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
